### PR TITLE
Split colors into their own file

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -374,3 +374,13 @@
   color: white;
 }
 
+/* APP WIDGET OVERRIDES */
+
+popover button,
+.popover .button {
+	border: none;
+	border-radius: 0;
+	text-shadow: none;
+	box-shadow: none;
+}
+

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ executable(
     'src/Colors.vala',
     'src/MainWindow.vala',
     'src/Widgets/ColorButton.vala',
+    'src/Widgets/ColorVariant.vala',
     dependencies: [
         dependency('gee-0.8'),
         dependency('glib-2.0'),

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ executable(
     'src/MainWindow.vala',
     'src/Widgets/ColorButton.vala',
     dependencies: [
+        dependency('gee-0.8'),
         dependency('glib-2.0'),
         dependency('gtk+-3.0')
     ],

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ executable(
     meson.project_name(),
     asresources,
     'src/Application.vala',
+    'src/Colors.vala',
     'src/MainWindow.vala',
     'src/Widgets/ColorButton.vala',
     dependencies: [

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,3 +1,4 @@
-src/MainWindow.vala
 src/Application.vala
+src/Colors.vala
+src/MainWindow.vala
 src/Widgets/ColorButton.vala

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,3 +2,4 @@ src/Application.vala
 src/Colors.vala
 src/MainWindow.vala
 src/Widgets/ColorButton.vala
+src/Widgets/ColorVariant.vala

--- a/src/Colors.vala
+++ b/src/Colors.vala
@@ -68,7 +68,7 @@ public enum Color {
         }
     }
     
-    public string class_name () {
+    public string style_class () {
         switch (this) {
             case STRAWBERRY:
                 return "strawberry";

--- a/src/Colors.vala
+++ b/src/Colors.vala
@@ -35,36 +35,26 @@ public enum Color {
         switch (this) {
             case STRAWBERRY:
                 return _("Strawberry");
-
             case ORANGE:
                 return _("Orange");
-
             case BANANA:
                 return _("Banana");
-
             case LIME:
                 return _("Lime");
-
             case BLUEBERRY:
                 return _("Blueberry");
-
             case GRAPE:
                 return _("Grape");
-
             case COCOA:
                 return _("Cocoa");
-
             case SILVER:
                 return _("Silver");
-
             case SLATE:
                 return _("Slate");
-
             case BLACK:
                 return _("Black");
-
             default:
-                assert_not_reached();
+                assert_not_reached ();
         }
     }
     
@@ -72,37 +62,108 @@ public enum Color {
         switch (this) {
             case STRAWBERRY:
                 return "strawberry";
-
             case ORANGE:
                 return "orange";
-
             case BANANA:
                 return "banana";
-
             case LIME:
                 return "lime";
-
             case BLUEBERRY:
                 return "blueberry";
-
             case GRAPE:
                 return "grape";
-
             case COCOA:
                 return "cocoa";
-
             case SILVER:
                 return "silver";
-
             case SLATE:
                 return "slate";
-
             case BLACK:
                 return "black";
-
             default:
-                assert_not_reached();
+                assert_not_reached ();
         }
+    }
+    
+    public Gee.HashMap<int, string> hex () {
+        var hex = new Gee.HashMap<int, string> ();
+
+        switch (this) {
+            case STRAWBERRY:
+                hex.set (100, "#ff8c82");
+                hex.set (300, "#ed5353");
+                hex.set (500, "#c6262e");
+                hex.set (700, "#a10705");
+                hex.set (900, "#7a0000");
+                break;
+            case ORANGE:
+                hex.set (100, "#ffc27d");
+                hex.set (300, "#ffa154");
+                hex.set (500, "#f37329");
+                hex.set (700, "#cc3b02");
+                hex.set (900, "#a62100");
+                break;
+            case BANANA:
+                hex.set (100, "#fff394");
+                hex.set (300, "#ffe16b");
+                hex.set (500, "#f9c440");
+                hex.set (700, "#d48e15");
+                hex.set (900, "#ad5f00");
+                break;
+            case LIME:
+                hex.set (100, "#d1ff82");
+                hex.set (300, "#9bdb4d");
+                hex.set (500, "#68b723");
+                hex.set (700, "#3a9104");
+                hex.set (900, "#206b00");
+                break;
+            case BLUEBERRY:
+                hex.set (100, "#8cd5ff");
+                hex.set (300, "#64baff");
+                hex.set (500, "#3689e6");
+                hex.set (700, "#0d52bf");
+                hex.set (900, "#002e99");
+                break;
+            case GRAPE:
+                hex.set (100, "#e29ffc");
+                hex.set (300, "#ad65d6");
+                hex.set (500, "#7a36b1");
+                hex.set (700, "#4c158a");
+                hex.set (900, "#260063");
+                break;
+            case COCOA:
+                hex.set (100, "#a3907c");
+                hex.set (300, "#8a715e");
+                hex.set (500, "#715344");
+                hex.set (700, "#57392d");
+                hex.set (900, "#3d211b");
+                break;
+            case SILVER:
+                hex.set (100, "#fafafa");
+                hex.set (300, "#d4d4d4");
+                hex.set (500, "#abacae");
+                hex.set (700, "#7e8087");
+                hex.set (900, "#555761");
+                break;
+            case SLATE:
+                hex.set (100, "#95a3ab");
+                hex.set (300, "#667885");
+                hex.set (500, "#485a6c");
+                hex.set (700, "#273445");
+                hex.set (900, "#0e141f");
+                break;
+            case BLACK:
+                hex.set (100, "#666666");
+                hex.set (300, "#4d4d4d");
+                hex.set (500, "#333333");
+                hex.set (700, "#1a1a1a");
+                hex.set (900, "#000000");
+                break;
+            default:
+                assert_not_reached ();
+        }
+        
+        return hex;
     }
 }
 

--- a/src/Colors.vala
+++ b/src/Colors.vala
@@ -1,0 +1,108 @@
+/*
+* Copyright (c) 2018 Cassidy James Blaede (https://cassidyjames.com)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Cassidy James Blaede <c@ssidyjam.es>
+*/
+
+public enum Color {
+    STRAWBERRY,
+    ORANGE,
+    BANANA,
+    LIME,
+    BLUEBERRY,
+    GRAPE,
+    COCOA,
+    SILVER,
+    SLATE,
+    BLACK;
+    
+    public string to_string () {
+        switch (this) {
+            case STRAWBERRY:
+                return _("Strawberry");
+
+            case ORANGE:
+                return _("Orange");
+
+            case BANANA:
+                return _("Banana");
+
+            case LIME:
+                return _("Lime");
+
+            case BLUEBERRY:
+                return _("Blueberry");
+
+            case GRAPE:
+                return _("Grape");
+
+            case COCOA:
+                return _("Cocoa");
+
+            case SILVER:
+                return _("Silver");
+
+            case SLATE:
+                return _("Slate");
+
+            case BLACK:
+                return _("Black");
+
+            default:
+                assert_not_reached();
+        }
+    }
+    
+    public string class_name () {
+        switch (this) {
+            case STRAWBERRY:
+                return "strawberry";
+
+            case ORANGE:
+                return "orange";
+
+            case BANANA:
+                return "banana";
+
+            case LIME:
+                return "lime";
+
+            case BLUEBERRY:
+                return "blueberry";
+
+            case GRAPE:
+                return "grape";
+
+            case COCOA:
+                return "cocoa";
+
+            case SILVER:
+                return "silver";
+
+            case SLATE:
+                return "slate";
+
+            case BLACK:
+                return "black";
+
+            default:
+                assert_not_reached();
+        }
+    }
+}
+

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -41,16 +41,16 @@ public class MainWindow : Gtk.Window {
         header_context.add_class ("default-decoration");
         header_context.add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var strawberry_button = new ColorButton ("strawberry", _("Strawberry"));
-        var orange_button = new ColorButton ("orange", _("Orange"));
-        var banana_button = new ColorButton ("banana", _("Banana"));
-        var lime_button = new ColorButton ("lime", _("Lime"));
-        var blueberry_button = new ColorButton ("blueberry", _("Blueberry"));
-        var grape_button = new ColorButton ("grape", _("Grape"));
-        var cocoa_button = new ColorButton ("cocoa", _("Cocoa"));
-        var silver_button = new ColorButton ("silver", _("Silver"));
-        var slate_button = new ColorButton ("slate", _("Slate"));
-        var black_button = new ColorButton ("black", _("Black"));
+        var strawberry_button = new ColorButton (Color.STRAWBERRY);
+        var orange_button = new ColorButton (Color.ORANGE);
+        var banana_button = new ColorButton (Color.BANANA);
+        var lime_button = new ColorButton (Color.LIME);
+        var blueberry_button = new ColorButton (Color.BLUEBERRY);
+        var grape_button = new ColorButton (Color.GRAPE);
+        var cocoa_button = new ColorButton (Color.COCOA);
+        var silver_button = new ColorButton (Color.SILVER);
+        var slate_button = new ColorButton (Color.SLATE);
+        var black_button = new ColorButton (Color.BLACK);
 
         var main_layout = new Gtk.Grid ();
         main_layout.column_spacing = main_layout.row_spacing = 12;
@@ -59,7 +59,7 @@ public class MainWindow : Gtk.Window {
         main_layout.attach (strawberry_button, 0, 0, 1, 1);
         main_layout.attach (orange_button,     1, 0, 1, 1);
         main_layout.attach (banana_button,     2, 0, 1, 1);
-        main_layout.attach (lime_button,       3, 0, 1, 1);        
+        main_layout.attach (lime_button,       3, 0, 1, 1);
         main_layout.attach (blueberry_button,  4, 0, 1, 1);
         main_layout.attach (grape_button,      5, 0, 1, 1);
 

--- a/src/Widgets/ColorButton.vala
+++ b/src/Widgets/ColorButton.vala
@@ -20,48 +20,46 @@
 */
 
 public class ColorButton : Gtk.Button {
-    public string class_name { get; construct; }
-    public string human { get; construct; }
-
-    public ColorButton (string class_name, string human) {
+    public Color color { get; construct; }
+    
+    public ColorButton (Color color) {
         Object (
             height_request: 128,
             width_request: 128,
-            class_name: class_name,
-            human: human,
-            tooltip_text: human
+            color: color,
+            tooltip_text: color.to_string ()
         );
     }
 
     construct {
         var color_context = get_style_context ();
-        color_context.add_class (class_name);
+        color_context.add_class (color.class_name ());
         color_context.add_class ("circular");
 
-        var color_100 = new Gtk.Label ("%s 100".printf (human));
+        var color_100 = new Gtk.Label ("%s 100".printf (color.to_string ()));
         color_100.hexpand = true;
         color_100.height_request = 48;
-        color_100.get_style_context ().add_class ("%s-100".printf (class_name));
+        color_100.get_style_context ().add_class ("%s-100".printf (color.class_name ()));
 
-        var color_300 = new Gtk.Label ("%s 300".printf (human));
+        var color_300 = new Gtk.Label ("%s 300".printf (color.to_string ()));
         color_300.hexpand = true;
         color_300.height_request = 48;
-        color_300.get_style_context ().add_class ("%s-300".printf (class_name));
+        color_300.get_style_context ().add_class ("%s-300".printf (color.class_name ()));
 
-        var color_500 = new Gtk.Label ("%s 500".printf (human));
+        var color_500 = new Gtk.Label ("%s 500".printf (color.to_string ()));
         color_500.hexpand = true;
         color_500.height_request = 48;
-        color_500.get_style_context ().add_class ("%s-500".printf (class_name));
+        color_500.get_style_context ().add_class ("%s-500".printf (color.class_name ()));
 
-        var color_700 = new Gtk.Label ("%s 700".printf (human));
+        var color_700 = new Gtk.Label ("%s 700".printf (color.to_string ()));
         color_700.hexpand = true;
         color_700.height_request = 48;
-        color_700.get_style_context ().add_class ("%s-700".printf (class_name));
+        color_700.get_style_context ().add_class ("%s-700".printf (color.class_name ()));
 
-        var color_900 = new Gtk.Label ("%s 900".printf (human));
+        var color_900 = new Gtk.Label ("%s 900".printf (color.to_string ()));
         color_900.hexpand = true;
         color_900.height_request = 48;
-        color_900.get_style_context ().add_class ("%s-900".printf (class_name));
+        color_900.get_style_context ().add_class ("%s-900".printf (color.class_name ()));
 
         var color_grid = new Gtk.Grid ();
         color_grid.width_request = 200;

--- a/src/Widgets/ColorButton.vala
+++ b/src/Widgets/ColorButton.vala
@@ -36,67 +36,11 @@ public class ColorButton : Gtk.Button {
         color_context.add_class (color.style_class ());
         color_context.add_class ("circular");
 
-        // TODO: Abstract color labels to their own widget
-
-        var color_100 = new Gtk.Button.with_label ("%s 100 %s".printf (
-            color.to_string (), 
-            color.hex ()[100]
-        ));
-        color_100.hexpand = true;
-        color_100.height_request = 48;
-        color_100.get_style_context ().add_class ("%s-100".printf (color.style_class ()));
-        color_100.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[100]);
-        color_100.clicked.connect (() => {
-            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[100], -1);
-        });
-
-        var color_300 = new Gtk.Button.with_label ("%s 300 %s".printf (
-            color.to_string (), 
-            color.hex ()[300]
-        ));
-        color_300.hexpand = true;
-        color_300.height_request = 48;
-        color_300.get_style_context ().add_class ("%s-300".printf (color.style_class ()));
-        color_300.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[300]);
-        color_300.clicked.connect (() => {
-            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[300], -1);
-        });
-
-        var color_500 = new Gtk.Button.with_label ("%s 500 %s".printf (
-            color.to_string (), 
-            color.hex ()[500]
-        ));
-        color_500.hexpand = true;
-        color_500.height_request = 48;
-        color_500.get_style_context ().add_class ("%s-500".printf (color.style_class ()));
-        color_500.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[500]);
-        color_500.clicked.connect (() => {
-            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[500], -1);
-        });
-
-        var color_700 = new Gtk.Button.with_label ("%s 700 %s".printf (
-            color.to_string (), 
-            color.hex ()[700]
-        ));
-        color_700.hexpand = true;
-        color_700.height_request = 48;
-        color_700.get_style_context ().add_class ("%s-700".printf (color.style_class ()));
-        color_700.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[700]);
-        color_700.clicked.connect (() => {
-            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[700], -1);
-        });
-
-        var color_900 = new Gtk.Button.with_label ("%s 900 %s".printf (
-            color.to_string (), 
-            color.hex ()[900]
-        ));
-        color_900.hexpand = true;
-        color_900.height_request = 48;
-        color_900.get_style_context ().add_class ("%s-900".printf (color.style_class ()));
-        color_900.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[900]);
-        color_900.clicked.connect (() => {
-            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[900], -1);
-        });
+        var color_100 = new ColorVariant (color, 100);
+        var color_300 = new ColorVariant (color, 300);
+        var color_500 = new ColorVariant (color, 500);
+        var color_700 = new ColorVariant (color, 700);
+        var color_900 = new ColorVariant (color, 900);
 
         var color_grid = new Gtk.Grid ();
         color_grid.width_request = 200;

--- a/src/Widgets/ColorButton.vala
+++ b/src/Widgets/ColorButton.vala
@@ -36,30 +36,67 @@ public class ColorButton : Gtk.Button {
         color_context.add_class (color.style_class ());
         color_context.add_class ("circular");
 
-        var color_100 = new Gtk.Label ("%s 100".printf (color.to_string ()));
+        // TODO: Abstract color labels to their own widget
+
+        var color_100 = new Gtk.Button.with_label ("%s 100 %s".printf (
+            color.to_string (), 
+            color.hex ()[100]
+        ));
         color_100.hexpand = true;
         color_100.height_request = 48;
         color_100.get_style_context ().add_class ("%s-100".printf (color.style_class ()));
+        color_100.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[100]);
+        color_100.clicked.connect (() => {
+            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[100], -1);
+        });
 
-        var color_300 = new Gtk.Label ("%s 300".printf (color.to_string ()));
+        var color_300 = new Gtk.Button.with_label ("%s 300 %s".printf (
+            color.to_string (), 
+            color.hex ()[300]
+        ));
         color_300.hexpand = true;
         color_300.height_request = 48;
         color_300.get_style_context ().add_class ("%s-300".printf (color.style_class ()));
+        color_300.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[300]);
+        color_300.clicked.connect (() => {
+            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[300], -1);
+        });
 
-        var color_500 = new Gtk.Label ("%s 500".printf (color.to_string ()));
+        var color_500 = new Gtk.Button.with_label ("%s 500 %s".printf (
+            color.to_string (), 
+            color.hex ()[500]
+        ));
         color_500.hexpand = true;
         color_500.height_request = 48;
         color_500.get_style_context ().add_class ("%s-500".printf (color.style_class ()));
+        color_500.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[500]);
+        color_500.clicked.connect (() => {
+            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[500], -1);
+        });
 
-        var color_700 = new Gtk.Label ("%s 700".printf (color.to_string ()));
+        var color_700 = new Gtk.Button.with_label ("%s 700 %s".printf (
+            color.to_string (), 
+            color.hex ()[700]
+        ));
         color_700.hexpand = true;
         color_700.height_request = 48;
         color_700.get_style_context ().add_class ("%s-700".printf (color.style_class ()));
+        color_700.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[700]);
+        color_700.clicked.connect (() => {
+            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[700], -1);
+        });
 
-        var color_900 = new Gtk.Label ("%s 900".printf (color.to_string ()));
+        var color_900 = new Gtk.Button.with_label ("%s 900 %s".printf (
+            color.to_string (), 
+            color.hex ()[900]
+        ));
         color_900.hexpand = true;
         color_900.height_request = 48;
         color_900.get_style_context ().add_class ("%s-900".printf (color.style_class ()));
+        color_900.tooltip_text = _("Copy %s to clipboard").printf (color.hex ()[900]);
+        color_900.clicked.connect (() => {
+            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[900], -1);
+        });
 
         var color_grid = new Gtk.Grid ();
         color_grid.width_request = 200;

--- a/src/Widgets/ColorButton.vala
+++ b/src/Widgets/ColorButton.vala
@@ -33,33 +33,33 @@ public class ColorButton : Gtk.Button {
 
     construct {
         var color_context = get_style_context ();
-        color_context.add_class (color.class_name ());
+        color_context.add_class (color.style_class ());
         color_context.add_class ("circular");
 
         var color_100 = new Gtk.Label ("%s 100".printf (color.to_string ()));
         color_100.hexpand = true;
         color_100.height_request = 48;
-        color_100.get_style_context ().add_class ("%s-100".printf (color.class_name ()));
+        color_100.get_style_context ().add_class ("%s-100".printf (color.style_class ()));
 
         var color_300 = new Gtk.Label ("%s 300".printf (color.to_string ()));
         color_300.hexpand = true;
         color_300.height_request = 48;
-        color_300.get_style_context ().add_class ("%s-300".printf (color.class_name ()));
+        color_300.get_style_context ().add_class ("%s-300".printf (color.style_class ()));
 
         var color_500 = new Gtk.Label ("%s 500".printf (color.to_string ()));
         color_500.hexpand = true;
         color_500.height_request = 48;
-        color_500.get_style_context ().add_class ("%s-500".printf (color.class_name ()));
+        color_500.get_style_context ().add_class ("%s-500".printf (color.style_class ()));
 
         var color_700 = new Gtk.Label ("%s 700".printf (color.to_string ()));
         color_700.hexpand = true;
         color_700.height_request = 48;
-        color_700.get_style_context ().add_class ("%s-700".printf (color.class_name ()));
+        color_700.get_style_context ().add_class ("%s-700".printf (color.style_class ()));
 
         var color_900 = new Gtk.Label ("%s 900".printf (color.to_string ()));
         color_900.hexpand = true;
         color_900.height_request = 48;
-        color_900.get_style_context ().add_class ("%s-900".printf (color.class_name ()));
+        color_900.get_style_context ().add_class ("%s-900".printf (color.style_class ()));
 
         var color_grid = new Gtk.Grid ();
         color_grid.width_request = 200;

--- a/src/Widgets/ColorVariant.vala
+++ b/src/Widgets/ColorVariant.vala
@@ -45,7 +45,7 @@ public class ColorVariant : Gtk.Button {
         ));
         
         this.clicked.connect (() => {
-            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[100], -1);
+            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[variant], -1);
         });
     }
 }

--- a/src/Widgets/ColorVariant.vala
+++ b/src/Widgets/ColorVariant.vala
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2018 Cassidy James Blaede (https://cassidyjames.com)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Cassidy James Blaede <c@ssidyjam.es>
+*/
+
+public class ColorVariant : Gtk.Button {
+    public Color color { get; construct; }
+    public int variant { get; construct; }
+    
+    public ColorVariant (Color color, int variant) {
+        Object (
+            color: color,
+            height_request: 48,
+            hexpand: true,
+            label: "%s %i %s".printf (
+                color.to_string (),
+                variant,
+                color.hex ()[variant]
+            ),
+            tooltip_text: _("Copy %s to clipboard").printf (color.hex ()[variant]),
+            variant: variant
+        );
+    }
+
+    construct {
+        get_style_context ().add_class ("%s-%i".printf (
+            color.style_class (), 
+            variant
+        ));
+        
+        this.clicked.connect (() => {
+            Gtk.Clipboard.get_default (this.get_display ()).set_text (color.hex ()[100], -1);
+        });
+    }
+}


### PR DESCRIPTION
This seems sane to not have to keep track of everything in the middle of the main file, but it also looks a lot more verbose. :man_shrugging: 

I think it'll help when I start having the 100, 300, 500, 700, and 900 variants in the application itself instead of just in the CSS.